### PR TITLE
implemented animation changes depending on happiness and hunger stats

### DIFF
--- a/components/Pet.jsx
+++ b/components/Pet.jsx
@@ -16,7 +16,7 @@ class Pet extends Component {
       name: 'Firulai',
       growthlvl: 0,
       hunger: 0,
-      happiness: 100,
+      happiness: 80,
       lastInteractionTime: new Date(),
       careMistakes: 0,
     };
@@ -43,10 +43,10 @@ class Pet extends Component {
         nextIndex = this.state.images.findIndex(image => image === require('./animatedFrog(angry).gif'));
       } else if (this.state.happiness >= 80) {
         nextIndex = this.state.images.findIndex(image => image === require('./animatedFrog(happy).gif'));
-      } else if (this.state.happiness >= 50) {
+      } else if (this.state.happiness >= 40) {
         nextIndex = this.state.images.findIndex(image => image === require('./animatedFrog.gif'));
 
-      } else if (this.state.happiness >= 20 || this.state.happiness <=20) {
+      } else if (this.state.happiness >= 30 || this.state.happiness <= 30) {
         nextIndex = this.state.images.findIndex(image => image === require('./animatedFrog(sad).gif')); 
       } 
   // Update the currentImageIndex state with the index of the selected image

--- a/components/Pet.jsx
+++ b/components/Pet.jsx
@@ -9,7 +9,7 @@ class Pet extends Component {
         require('./animatedFrog.gif'),
         require('./animatedFrog(sad).gif'),
         require('./animatedFrog(happy).gif'),
-        require('./animatedFrog(happy).gif'),
+        require('./animatedFrog(angry).gif'),
         require('./animatedFrog(dead).gif'),
       ],
       currentImageIndex: 0,
@@ -25,22 +25,33 @@ class Pet extends Component {
 
   componentDidMount() {
     // Simulate happiness increasing over time
-    const interval = setInterval(() => {
-      if (this.state.happiness < 100) {
-        this.setState((prevState) => ({
-          happiness: prevState.happiness + 10,
-        }));
-      } else {
-        clearInterval(interval);
-      }
-    }, 1000);
+    // const interval = setInterval(() => {
+    //   if (this.state.happiness < 100) {
+    //     this.setState((prevState) => ({
+    //       happiness: prevState.happiness + 10,
+    //     }));
+    //   } else {
+    //     clearInterval(interval);
+    //   }
+    // }, 2000);
 
-    // Switch images every 3 seconds
+    // Switch images every 2 seconds
     const imageInterval = setInterval(() => {
-      this.setState((prevState) => ({
-        currentImageIndex: (prevState.currentImageIndex + 1) % this.state.images.length,
-      }));
-    }, 3000);
+      let nextIndex;
+
+      if(this.state.hunger >= 50){
+        nextIndex = this.state.images.findIndex(image => image === require('./animatedFrog(angry).gif'));
+      } else if (this.state.happiness >= 80) {
+        nextIndex = this.state.images.findIndex(image => image === require('./animatedFrog(happy).gif'));
+      } else if (this.state.happiness >= 50) {
+        nextIndex = this.state.images.findIndex(image => image === require('./animatedFrog.gif'));
+
+      } else if (this.state.happiness >= 20 || this.state.happiness <=20) {
+        nextIndex = this.state.images.findIndex(image => image === require('./animatedFrog(sad).gif')); 
+      } 
+  // Update the currentImageIndex state with the index of the selected image
+    this.setState((prevState) => ({
+    currentImageIndex: nextIndex,}));}, 2000);
 
     // Check for care mistakes every 15 minutes
     const careMistakeInterval = setInterval(() => {


### PR DESCRIPTION
This pull is related towards issue #182 and #177. I was able to make changes in the animation depending on its stats: hunger and happiness. Right now the priority is hunger, then happiness. When hungry is 50 or higher, the pet becomes angrier. Once the hunger is lower than 50, then it changes to the animation where happiness is involved. The pet's happiness has different changes
 100-80 (happy), 40-79(regular animated frog), 39-0 is sad animation. All of this was done in Pet.jsx
![Screenshot 2024-03-20 195938](https://github.com/uprm-inso4117-2023-2024-s2/semester-project-study-pet/assets/70653201/d8f7ec91-bd85-4691-b0c1-8c922d1a6e73)

For me to test if it worked, I hardcoded the values inside the pet, since I have no control over the happiness or hunger. Mess around with the different ranges between happiness and hunger, and see if it is towards your liking
![Screenshot 2024-03-20 202632](https://github.com/uprm-inso4117-2023-2024-s2/semester-project-study-pet/assets/70653201/56d862e1-0161-4766-93b9-674c91c3bd9d)


